### PR TITLE
Add Bell state |Φ+ circuit model

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-submission-path-observable-estimations.yml
+++ b/.github/ISSUE_TEMPLATE/01-submission-path-observable-estimations.yml
@@ -35,6 +35,7 @@ body:
         - operator_loschmidt_echo_70x1872
         - operator_loschmidt_echo_49x648
         - operator_loschmidt_echo_49x1296
+        - bell_state_phi_plus_2qubit
     validations:
       required: true
 

--- a/data/observable-estimations/circuit-models.json
+++ b/data/observable-estimations/circuit-models.json
@@ -20,5 +20,15 @@
         "gates": 1872
       }
     ]
+  },
+  "bell_state_phi_plus": {
+    "instances": [
+      {
+        "id": "bell_state_phi_plus_2qubit",
+        "path": "bell_phi_plus.qasm",
+        "qubits": 2,
+        "gates": 2
+      }
+    ]
   }
 }

--- a/data/observable-estimations/circuit-models/bell_state_phi_plus/README.md
+++ b/data/observable-estimations/circuit-models/bell_state_phi_plus/README.md
@@ -1,0 +1,27 @@
+# Bell State |Φ+⟩ Circuit
+
+## Description
+
+Two-qubit Bell state preparation circuit creating the maximally entangled state:
+
+|Φ+⟩ = (|00⟩ + |11⟩)/√2
+
+## Circuit Structure
+
+1. Hadamard gate on qubit 0: Creates superposition
+2. CNOT gate (control=0, target=1): Creates entanglement
+
+## Observables
+
+- X-basis correlation: ⟨X₁X₂⟩
+- Y-basis anti-correlation: ⟨Y₁Y₂⟩  
+- Z-basis correlation: ⟨Z₁Z₂⟩
+
+## Institutions
+
+UCP Technology LLC
+
+## References
+
+- "Complete Quantum State Recovery from Single-Basis Measurements via Frequency Signatures" - Roy & Ellison 2025
+

--- a/data/observable-estimations/circuit-models/bell_state_phi_plus/bell_phi_plus.qasm
+++ b/data/observable-estimations/circuit-models/bell_state_phi_plus/bell_phi_plus.qasm
@@ -1,0 +1,10 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+// Bell state |Φ+⟩ = (|00⟩ + |11⟩)/√2
+h q[0];
+cx q[0], q[1];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+


### PR DESCRIPTION
Adds 2-qubit Bell state circuit for observable estimation submissions

- Created bell_state_phi_plus model directory with QASM circuit file

- Added README.md with circuit description, observables, and references

- Updated circuit-models.json with bell_state_phi_plus_2qubit instance

- Updated issue template to include new circuit instance in dropdown