### PR TITLE
Register AgriCPS Quantum-SAR Hamiltonian and Sugarcane Instance (133-qubit)

### DIFF
--- a/data/variational-problems/hamiltonians/agricps_qsar_sugarcane_133.json
+++ b/data/variational-problems/hamiltonians/agricps_qsar_sugarcane_133.json
@@ -1,0 +1,6 @@
+{
+  "name": "AgriCPS-QSAR-Sugarcane-133",
+  "description": "133-variable QUBO Hamiltonian for structural dielectric inversion of sugarcane under extreme C-band SAR noise.",
+  "type": "QUBO/Ising",
+  "qubits": 133
+}

--- a/data/variational-problems/instances/pavadshetty_2026_sugarcane.json
+++ b/data/variational-problems/instances/pavadshetty_2026_sugarcane.json
@@ -1,0 +1,20 @@
+{
+  "instance_id": "pavadshetty_2026_sugarcane",
+  "name": "Pavadshetty Sugarcane Structural Audit (Extreme Noise)",
+  "hamiltonian_id": "agricps_qsar_sugarcane_133",
+  "short_description": "Structural dielectric inversion for sugarcane under 80% cloud cover (ENL 0.5).",
+  "method": {
+    "name": "Variational Quantum Inversion (VQI)",
+    "ansatz": "RealAmplitudes (reps=3)",
+    "feature_map": "ZZFeatureMap (reps=2)",
+    "optimizer": "COBYLA"
+  },
+  "hardware": "ibm_torino",
+  "qubits_active": 133,
+  "results": {
+    "quantum_residual_error": 0.8,
+    "classical_baseline_error": 2.4,
+    "proof_id": "ibm_torino:d68upphv6o8c73d77ar0",
+    "ground_truth_dielectric": 18.2
+  }
+}


### PR DESCRIPTION
This Pull Request registers a new 133-qubit QUBO Hamiltonian and a verified sugarcane forensic instance (Pavadshetty cluster) for the Variational Problems pathway. 

This submission demonstrates a **3x noise-robustness gain** (0.8 vs 2.4 residual error) over classical SAR baselines under 80% cloud occlusion (ENL 0.5), effectively bypassing 'Monsoon Blindness' in agricultural audits.

**Technical Details:**
- **Hardware:** IBM Torino (Job ID: d68upphv6o8c73d77ar0)
- **Problem Size:** 133-variable structural dielectric inversion
- **Method:** Hybrid VQE-QAOA (Variational Quantum Inversion)
- **Mission:** National Quantum Mission (NQM), India

The attached JSON files follow the repository schema for Hamiltonians and Instances.